### PR TITLE
Right sidebar alterations

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -192,8 +192,8 @@ body[data-page=whiteboard] #app-container {
         border: 1px solid var(--ls-left-sidebar-border-color,var(--lx-gray-03,var(--ls-tertiary-background-color)));
         box-shadow: none;
         &:hover,
-        &:hover div > *,
-        &:hover div[role=region] > * /* band-aid for page graph */ {
+        &:hover div > *:not(button),
+        &:hover div[role=region] > *:not(button) /* band-aid for page graph */ {
             background: var(--ls-menu-hover-color);
             border-radius: 4px;
         }

--- a/src/base.css
+++ b/src/base.css
@@ -188,15 +188,8 @@ body[data-page=whiteboard] #app-container {
     .cp__right-sidebar-inner { /* apply border to right sidebar as with left sidebar */
         border-left: 1px solid var(--ls-left-sidebar-border-color,var(--lx-gray-03,var(--ls-tertiary-background-color)));
     }
-    .sidebar-item-list > .sidebar-item { /* change sidebar item aesthetic */
-        border: 1px solid var(--ls-left-sidebar-border-color,var(--lx-gray-03,var(--ls-tertiary-background-color)));
+    .sidebar-item-list > .sidebar-item {
         box-shadow: none;
-        &:hover,
-        &:hover div > *:not(button),
-        &:hover div[role=region] > *:not(button) /* band-aid for page graph */ {
-            background: var(--ls-menu-hover-color);
-            border-radius: 4px;
-        }
     }
 }
 

--- a/src/base.css
+++ b/src/base.css
@@ -184,6 +184,21 @@ body[data-page=whiteboard] #app-container {
     color: var(--ls-link-ref-text-hover-color);
 }
 
+#right-sidebar {
+    .cp__right-sidebar-inner { /* apply border to right sidebar as with left sidebar */
+        border-left: 1px solid var(--ls-left-sidebar-border-color,var(--lx-gray-03,var(--ls-tertiary-background-color)));
+    }
+    .sidebar-item-list > .sidebar-item { /* change sidebar item aesthetic */
+        border: 1px solid var(--ls-left-sidebar-border-color,var(--lx-gray-03,var(--ls-tertiary-background-color)));
+        box-shadow: none;
+        &:hover,
+        &:hover div > *,
+        &:hover div[role=region] > * /* band-aid for page graph */ {
+            background: var(--ls-menu-hover-color);
+            border-radius: 4px;
+        }
+    }
+}
 
 /* left sidebar */
 


### PR DESCRIPTION
To make it more consistent with the left sidebar.
- Right sidebar now has a left border.
- Hovered-over sidebar items are now highlighted as with left sidebar items.
- Replaced box shadow with all-around border — a little out of place but better than before.

Apologies if nested CSS is not the preferred syntax.

![image](https://github.com/user-attachments/assets/024549f1-e7a2-4635-a0e5-9563b1d34db1)
